### PR TITLE
ports/rp2: Fix flash size check in CMakeLists.txt.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -528,7 +528,7 @@ target_link_options(${MICROPY_TARGET} PRIVATE
     -Wl,--wrap=runtime_init_clocks
 )
 
-if(PICO_FLASH_SIZE_BYTES GREATER 0)
+if(DEFINED PICO_FLASH_SIZE_BYTES)
     target_link_options(${MICROPY_TARGET} PRIVATE
         -Wl,--defsym=__micropy_flash_size__=${PICO_FLASH_SIZE_BYTES}
     )


### PR DESCRIPTION
### Summary

See https://github.com/micropython/micropython/pull/17344#issuecomment-3050389938

### Testing

Tested building a handful of boards with a debug print added to each `if()` branch to verify the correct branch is executed.

